### PR TITLE
Fix: Replace 'pref' with 'priority' in ip rule for Android compatibility

### DIFF
--- a/magisk/lib.sh
+++ b/magisk/lib.sh
@@ -14,8 +14,8 @@ export LD_LIBRARY_PATH=/system/lib64:/data/adb/zerotier/lib
 
 __start() {
   # add main route table to lookup rules
-  ip rule add from all lookup main pref 1
-  ip -6 rule add from all lookup main pref 1
+  ip rule add from all lookup main priority 1
+  ip -6 rule add from all lookup main priority 1
 
   # start zerotier daemon
   nohup $ZTROOT/zerotier-one -d >> $ZT_LOG 2>&1 &


### PR DESCRIPTION
## Summary
Fix ZeroTier connectivity on Android 14+ devices by replacing unsupported 'pref' keyword with 'priority' in ip rule commands.

## Problem
After installing zerotier-magisk on Android 14 (API 34), ZeroTier service was running and connected, but pinging other devices resulted in 100% packet loss. The routing table showed correct routes, but they weren't being used.

## Root Cause
The Magisk module's `service.sh` script attempted to add a high-priority routing rule:
```bash
ip rule add from all lookup main pref 1
ip -6 rule add from all lookup main pref 1
```

The `pref` keyword is not supported by Android's `ip` command (correct keyword is `priority`), causing these commands to fail silently on every boot. Without this rule, Android's default policy routing rules (priority 10000+) took precedence.

## Solution
Changed `pref 1` to `priority 1` in `magisk/lib.sh` __start() function.

## Testing
- Device: Infinix X6833B (Android 14, API 34)
- Architecture: arm64-v8a
- IP command: iproute2-ss171113
- ZeroTier: 1.14.2
- Module: zerotier-magisk-aarch64-gcc-SSO-e2c0c3a

Verified:
- `ip rule add from all lookup main priority 1` works correctly
- Routing rule persists after reboot
- ZeroTier peers accessible without manual interface specification